### PR TITLE
Fix Node Version pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
-ARG NODE_VERSION=18
+arg NODE_VERSION=18
 
-FROM node:${NODE_VERSION} AS build
+from node:${NODE_VERSION} as build
 workdir /app
 run apt-get update > /dev/null && apt-get -y install python3-pip > /dev/null
 run mkdir certs && openssl req -x509 -newkey rsa:2048 -sha256 -days 36500 -nodes -keyout certs/privkey.pem -out certs/fullchain.pem -subj '/CN=dialog'
@@ -9,9 +9,9 @@ copy package.json .
 copy package-lock.json .
 run npm ci
 copy . .
-from node:lts-slim
+from node:${NODE_VERSION}-slim
 workdir /app
 copy --from=build /app /app
 run apt-get update > /dev/null && apt-get install -y jq curl dnsutils netcat > /dev/null
 copy scripts/docker/run.sh /run.sh
-cmd bash /run.sh
+cmd ["bash", "/run.sh"]


### PR DESCRIPTION
the new lts version of node is 20 now, so the docker build fails with incompatible node modules, because the build version is 18.x.x and the run version is 20.x.x 

Using the node version pinning also for the "runtime-version" fixes this issue. 

The other modifications are just to get rid of some docker build warnings.